### PR TITLE
Move switches for model variables up the code

### DIFF
--- a/ecosmo/ecosmo.F90
+++ b/ecosmo/ecosmo.F90
@@ -170,6 +170,16 @@
 !-----------------------------------------------------------------------
 !BOC
 
+   ! add switches
+   call self%get_parameter( self%use_cyanos,     'use_cyanos', '', 'switch cyanobacteria', default=.true.)
+   call self%get_parameter( self%couple_co2,     'couple_co2', '', 'switch coupling to carbonate module', default=.false.)
+   call self%get_parameter( self%use_chl,     'use_chl', '', 'switch chlorophyll/c dynamics', default=.true.)
+   call self%get_parameter( self%not_0d,     'not_0d', '', 'do not run the model in a 0D box', default=.true.)
+   call self%get_parameter( self%use_community_sinking, 'use_community_sinking','','community composition dependent sinking rates', default=.false.)   
+   call self%get_parameter( self%use_chl_in_PI_curve, 'use_chl_in_PI_curve','','activated chl dependent light limitation',default=.false.)
+   call self%get_parameter( self%turn_on_additional_diagnostics, 'turn_on_additional_diagnostics','','activates additional diagnostics for model debugging',default=.false.)
+   call self%get_parameter( self%use_coccolithophores,     'use_coccolithophores', '', 'switch coccolithophores', default=.false.)
+
    call self%get_parameter(self%zpr, 'zpr', '1/day', 'zpr_long_name_needed', default=0.001_rk, scale_factor=1.0_rk/sedy0)
    call self%get_parameter(self%frr, 'frr', '-', 'fraction of dissolved from det.', default=0.4_rk)
    call self%get_parameter(self%nfixation_minimum_daily_par, 'nfixation_minimum_daily_par', 'nfixation minimum daily par', default=40.0_rk)
@@ -183,7 +193,7 @@
    call self%get_parameter( self%BioC(1) , 'muPl',        '1/day',      'max growth rate for Pl',          default=1.30_rk,  scale_factor=1.0_rk/sedy0)
    call self%get_parameter( self%BioC(2) , 'muPs',        '1/day',      'max growth rate for Ps',          default=1.10_rk,  scale_factor=1.0_rk/sedy0)
    call self%get_parameter( self%BioC(3) , 'aa',          'm**2/W',     'photosynthesis ef-cy',            default=0.04_rk)
-   call self%get_parameter( self%BioC(4) , 'EXw',         '1/m',        'light extinction',                default=0.041_rk)
+   call self%get_parameter( self%BioC(4) , 'EXw',         '1/m',        'light extinction',                default=0.0_rk)
    if (self%use_chl) then
       call self%get_parameter( self%BioC(5) , 'Exphy',       'm**2/mgCHL', 'phyto self-shading',              default=0.04_rk )
    else
@@ -289,15 +299,7 @@
    call self%get_parameter( self%sinkBgD,   'sinkBgD',     'm/day', 'Detritus originating from cyanob. sinking rate',      default=5.0_rk, scale_factor=1.0_rk/sedy0)
    call self%get_parameter( self%sinkCoccoD,  'sinkCoccoD',   'm/day', 'Detritus originating from coccolith. sinking rate',  default=5.0_rk, scale_factor=1.0_rk/sedy0)
    call self%get_parameter( self%SiUptLim,  'SiUptLim',   'mgC/m3', 'Stop Si uptake below this concentration',  default=80.0_rk)
-   ! add switches
-   call self%get_parameter( self%use_cyanos,     'use_cyanos', '', 'switch cyanobacteria', default=.true.)
-   call self%get_parameter( self%couple_co2,     'couple_co2', '', 'switch coupling to carbonate module', default=.false.)
-   call self%get_parameter( self%use_chl,     'use_chl', '', 'switch chlorophyll/c dynamics', default=.true.)
-   call self%get_parameter( self%not_0d,     'not_0d', '', 'do not run the model in a 0D box', default=.true.)
-   call self%get_parameter( self%use_community_sinking, 'use_community_sinking','','community composition dependent sinking rates', default=.false.)   
-   call self%get_parameter( self%use_chl_in_PI_curve, 'use_chl_in_PI_curve','','activated chl dependent light limitation',default=.false.)
-   call self%get_parameter( self%turn_on_additional_diagnostics, 'turn_on_additional_diagnostics','','activates additional diagnostics for model debugging',default=.false.)
-   call self%get_parameter( self%use_coccolithophores,     'use_coccolithophores', '', 'switch coccolithophores', default=.false.)
+
    ! Register state variables
    call self%register_state_variable( self%id_no3,      'no3',     'mgC/m3',    'nitrate',                   minimum=0.0_rk,        vertical_movement=0.0_rk,  &
                                       initial_value=5.0_rk*redf(1)*redf(6)  )


### PR DESCRIPTION
use_chl switch was being called before it was declared, as a result defaulting to false in the beginning of the code. 

Jorn asked me to update the main branch with this because it was giving warning on his end.
I am already fixing this in ice algae branch as well.